### PR TITLE
Updating dependencies to latest stable release of netty + several fixes and improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.class
+target/
 
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Jmeter HTTP/2 sampler
 
 ## Dependencies
 
-* [Netty 5 and netty-tcnative](http://netty.io/)
+* [Netty 4.1.x and netty-tcnative](http://netty.io/)
 * [hpack](https://github.com/twitter/hpack)
 
 ## Quickstart

--- a/pom.xml
+++ b/pom.xml
@@ -21,12 +21,14 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-math3</artifactId>
             <version>${version.commons-math3}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-pool2</artifactId>
             <version>${version.commons-pool2}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
@@ -43,6 +45,7 @@
                     <artifactId>commons-pool2</artifactId>
                 </exclusion>
             </exclusions>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
@@ -59,6 +62,7 @@
                     <artifactId>commons-pool2</artifactId>
                 </exclusion>
             </exclusions>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
@@ -70,7 +74,40 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-tcnative</artifactId>
-            <version>1.1.33.Fork3</version>
+            <version>1.1.33.Fork22</version>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.5.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.0</version>
+                <configuration>
+                    <outputFile>
+                        target/${project.artifactId}-dist-${project.version}.jar
+                    </outputFile>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <properties>
         <version.org.apache.jmeter.all>2.13</version.org.apache.jmeter.all>
-        <version.netty-all>4.1.5.Final</version.netty-all>
+        <version.netty-all>4.1.6.Final</version.netty-all>
         <version.commons-pool2>2.4.2</version.commons-pool2>
         <version.commons-math3>3.5</version.commons-math3>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <properties>
         <version.org.apache.jmeter.all>2.13</version.org.apache.jmeter.all>
-        <version.netty-all>5.0.0.Alpha3-SNAPSHOT</version.netty-all>
+        <version.netty-all>4.1.5.Final</version.netty-all>
         <version.commons-pool2>2.4.2</version.commons-pool2>
         <version.commons-math3>3.5</version.commons-math3>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -1,40 +1,76 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-  <groupId>jmeter.plugins.http2.sampler</groupId>
-  <artifactId>HTTP2Sampler</artifactId>
-  <packaging>jar</packaging>
-  <version>1.0-SNAPSHOT</version>
-  <name>HTTP/2 Sampler as JMeter plugin</name>
+    <groupId>jmeter.plugins.http2.sampler</groupId>
+    <artifactId>HTTP2Sampler</artifactId>
+    <packaging>jar</packaging>
+    <version>1.0-SNAPSHOT</version>
+    <name>HTTP/2 Sampler as JMeter plugin</name>
 
-  <dependencies>
-    <dependency>
-      <groupId>org.apache.jmeter</groupId>
-      <artifactId>ApacheJMeter_core</artifactId>
-      <version>2.11</version>
-      <scope>test</scope>
-    </dependency>
+    <properties>
+        <version.org.apache.jmeter.all>2.13</version.org.apache.jmeter.all>
+        <version.netty-all>5.0.0.Alpha3-SNAPSHOT</version.netty-all>
+        <version.commons-pool2>2.4.2</version.commons-pool2>
+        <version.commons-math3>3.5</version.commons-math3>
+    </properties>
 
-    <dependency>
-      <groupId>org.apache.jmeter</groupId>
-      <artifactId>jorphan</artifactId>
-      <version>2.11</version>
-      <scope>test</scope>
-    </dependency>
+    <dependencies>
 
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-all</artifactId>
-      <version>5.0.0.Alpha2</version>
-      <scope>test</scope>
-    </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-math3</artifactId>
+            <version>${version.commons-math3}</version>
+        </dependency>
 
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-tcnative</artifactId>
-      <version>1.1.33.Fork3</version>
-      <scope>test</scope>
-    </dependency>
-  </dependencies>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-pool2</artifactId>
+            <version>${version.commons-pool2}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.jmeter</groupId>
+            <artifactId>ApacheJMeter_core</artifactId>
+            <version>${version.org.apache.jmeter.all}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-math3</groupId>
+                    <artifactId>commons-math3</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-pool2</groupId>
+                    <artifactId>commons-pool2</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.jmeter</groupId>
+            <artifactId>ApacheJMeter_http</artifactId>
+            <version>${version.org.apache.jmeter.all}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-math3</groupId>
+                    <artifactId>commons-math3</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-pool2</groupId>
+                    <artifactId>commons-pool2</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-all</artifactId>
+            <version>${version.netty-all}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-tcnative</artifactId>
+            <version>1.1.33.Fork3</version>
+        </dependency>
+    </dependencies>
 </project>

--- a/src/main/java/jmeter/plugins/http2/sampler/HTTP2Sampler.java
+++ b/src/main/java/jmeter/plugins/http2/sampler/HTTP2Sampler.java
@@ -115,6 +115,10 @@ public class HTTP2Sampler extends AbstractSampler {
       return getPropertyAsInt(PORT);
     }
 
+    public String getPortAsString() {
+        return getPropertyAsString(PORT);
+    }
+
     public void setPath(String value) {
       setProperty(PATH, value);
     }

--- a/src/main/java/jmeter/plugins/http2/sampler/HTTP2Sampler.java
+++ b/src/main/java/jmeter/plugins/http2/sampler/HTTP2Sampler.java
@@ -30,6 +30,7 @@ public class HTTP2Sampler extends AbstractSampler {
     private static final Logger log = LoggingManager.getLoggerForClass();
 
     public static final String METHOD = "HTTP2Sampler.method";
+    public static final String SCHEME = "HTTP2Sampler.scheme";
     public static final String DOMAIN = "HTTP2Sampler.domain";
     public static final String PORT = "HTTP2Sampler.port";
     public static final String PATH = "HTTP2Sampler.path";
@@ -75,7 +76,7 @@ public class HTTP2Sampler extends AbstractSampler {
         HeaderManager headerManager = (HeaderManager)getProperty(HTTPSamplerBase.HEADER_MANAGER).getObjectValue();
 
         // Send H2 request
-        NettyHttp2Client client = new NettyHttp2Client(getMethod(), getDomain(), getPort(), getPath(), headerManager);
+        NettyHttp2Client client = new NettyHttp2Client(getMethod(), getDomain(), getPort(), getPath(), headerManager, getScheme());
         SampleResult res = client.request();
         res.setSampleLabel(getName());
 
@@ -88,6 +89,14 @@ public class HTTP2Sampler extends AbstractSampler {
 
     public String getMethod() {
       return getPropertyAsString(METHOD);
+    }
+
+    public void setScheme(String value) {
+        setProperty(SCHEME, value);
+    }
+
+    public String getScheme() {
+        return getPropertyAsString(SCHEME);
     }
 
     public void setDomain(String value) {

--- a/src/main/java/jmeter/plugins/http2/sampler/HTTP2Sampler.java
+++ b/src/main/java/jmeter/plugins/http2/sampler/HTTP2Sampler.java
@@ -15,17 +15,13 @@
  */
 package jmeter.plugins.http2.sampler;
 
-import java.net.InetSocketAddress;
-import java.util.concurrent.Phaser;
-import java.util.concurrent.TimeUnit;
-
 import org.apache.jmeter.protocol.http.control.HeaderManager;
 import org.apache.jmeter.protocol.http.sampler.HTTPSamplerBase;
 import org.apache.jmeter.samplers.AbstractSampler;
 import org.apache.jmeter.samplers.Entry;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.testelement.TestElement;
-import org.apache.jmeter.testelement.property.*;
+import org.apache.jmeter.testelement.property.TestElementProperty;
 import org.apache.jorphan.logging.LoggingManager;
 import org.apache.log.Logger;
 
@@ -71,7 +67,6 @@ public class HTTP2Sampler extends AbstractSampler {
         }
     }
 
-    @Override
     public SampleResult sample(Entry e)
     {
         log.debug("sample()");

--- a/src/main/java/jmeter/plugins/http2/sampler/Http2ClientInitializer.java
+++ b/src/main/java/jmeter/plugins/http2/sampler/Http2ClientInitializer.java
@@ -19,8 +19,8 @@
 package jmeter.plugins.http2.sampler;
 
 import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelHandlerAdapter;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
@@ -47,8 +47,8 @@ import io.netty.handler.codec.http2.Http2FrameWriter;
 import io.netty.handler.codec.http2.Http2InboundFrameLogger;
 import io.netty.handler.codec.http2.Http2OutboundFrameLogger;
 import io.netty.handler.codec.http2.Http2Settings;
-import io.netty.handler.codec.http2.HttpToHttp2ConnectionHandler;
-import io.netty.handler.codec.http2.InboundHttp2ToHttpAdapter;
+import io.netty.handler.codec.http2.HttpToHttp2ConnectionHandlerBuilder;
+import io.netty.handler.codec.http2.InboundHttp2ToHttpAdapterBuilder;
 import io.netty.handler.codec.http2.StreamBufferingEncoder;
 import io.netty.handler.ssl.SslContext;
 
@@ -80,13 +80,15 @@ public class Http2ClientInitializer extends ChannelInitializer<SocketChannel> {
         encoder = new StreamBufferingEncoder(encoder, 100);
         Http2ConnectionDecoder decoder = new DefaultHttp2ConnectionDecoder(connection, encoder, frameReader());
 
-        connectionHandler = new HttpToHttp2ConnectionHandler.Builder()
+        connectionHandler = new HttpToHttp2ConnectionHandlerBuilder()
+                .connection(connection)
+                .codec(decoder, encoder)
                 .frameListener(new DelegatingDecompressorFrameListener(connection,
-                        new InboundHttp2ToHttpAdapter.Builder(connection)
+                        new InboundHttp2ToHttpAdapterBuilder(connection)
                                 .maxContentLength(maxContentLength)
                                 .propagateSettings(true)
                                 .build()))
-                .build(decoder, encoder);
+                .build();
 
 
 //        // Set initial SETTINGS
@@ -154,14 +156,15 @@ public class Http2ClientInitializer extends ChannelInitializer<SocketChannel> {
     /**
      * A handler that triggers the cleartext upgrade to HTTP/2 by sending an initial HTTP request.
      */
-    private final class UpgradeRequestHandler extends ChannelHandlerAdapter {
+    private final class UpgradeRequestHandler extends ChannelInboundHandlerAdapter {
         @Override
         public void channelActive(ChannelHandlerContext ctx) throws Exception {
             DefaultFullHttpRequest upgradeRequest =
                     new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/");
+            upgradeRequest.headers().add("Host", "default");
             ctx.writeAndFlush(upgradeRequest);
 
-            super.channelActive(ctx);
+            ctx.fireChannelActive();
 
             // Done with this handler, remove it from the pipeline.
             ctx.pipeline().remove(this);
@@ -173,11 +176,11 @@ public class Http2ClientInitializer extends ChannelInitializer<SocketChannel> {
     /**
      * Class that logs any User Events triggered on this channel.
      */
-    private static class UserEventLogger extends ChannelHandlerAdapter {
+    private static class UserEventLogger extends ChannelInboundHandlerAdapter {
         @Override
         public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
             System.out.println("User Event Triggered: " + evt);
-            super.userEventTriggered(ctx, evt);
+            ctx.fireUserEventTriggered(evt);
         }
     }
 

--- a/src/main/java/jmeter/plugins/http2/sampler/Http2ClientInitializer.java
+++ b/src/main/java/jmeter/plugins/http2/sampler/Http2ClientInitializer.java
@@ -31,15 +31,11 @@ import io.netty.handler.codec.http.HttpClientUpgradeHandler;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http2.DefaultHttp2Connection;
-import io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder;
-import io.netty.handler.codec.http2.DefaultHttp2ConnectionEncoder;
 import io.netty.handler.codec.http2.DefaultHttp2FrameReader;
 import io.netty.handler.codec.http2.DefaultHttp2FrameWriter;
 import io.netty.handler.codec.http2.DelegatingDecompressorFrameListener;
 import io.netty.handler.codec.http2.Http2ClientUpgradeCodec;
 import io.netty.handler.codec.http2.Http2Connection;
-import io.netty.handler.codec.http2.Http2ConnectionDecoder;
-import io.netty.handler.codec.http2.Http2ConnectionEncoder;
 import io.netty.handler.codec.http2.Http2ConnectionHandler;
 import io.netty.handler.codec.http2.Http2FrameLogger;
 import io.netty.handler.codec.http2.Http2FrameReader;
@@ -49,7 +45,6 @@ import io.netty.handler.codec.http2.Http2OutboundFrameLogger;
 import io.netty.handler.codec.http2.Http2Settings;
 import io.netty.handler.codec.http2.HttpToHttp2ConnectionHandlerBuilder;
 import io.netty.handler.codec.http2.InboundHttp2ToHttpAdapterBuilder;
-import io.netty.handler.codec.http2.StreamBufferingEncoder;
 import io.netty.handler.ssl.SslContext;
 
 import static io.netty.handler.logging.LogLevel.INFO;
@@ -76,18 +71,18 @@ public class Http2ClientInitializer extends ChannelInitializer<SocketChannel> {
     public void initChannel(SocketChannel ch) throws Exception {
         final Http2Connection connection = new DefaultHttp2Connection(false);
 
-        Http2ConnectionEncoder encoder = new DefaultHttp2ConnectionEncoder(connection, frameWriter());
-        encoder = new StreamBufferingEncoder(encoder, 100);
-        Http2ConnectionDecoder decoder = new DefaultHttp2ConnectionDecoder(connection, encoder, frameReader());
+//        Http2ConnectionEncoder encoder = new DefaultHttp2ConnectionEncoder(connection, frameWriter());
+//        encoder = new StreamBufferingEncoder(encoder, 100);
+//        Http2ConnectionDecoder decoder = new DefaultHttp2ConnectionDecoder(connection, encoder, frameReader());
 
         connectionHandler = new HttpToHttp2ConnectionHandlerBuilder()
-                .connection(connection)
-                .codec(decoder, encoder)
+//                .codec(decoder, encoder)
                 .frameListener(new DelegatingDecompressorFrameListener(connection,
                         new InboundHttp2ToHttpAdapterBuilder(connection)
                                 .maxContentLength(maxContentLength)
                                 .propagateSettings(true)
                                 .build()))
+                .connection(connection)
                 .build();
 
 

--- a/src/main/java/jmeter/plugins/http2/sampler/Http2SettingsHandler.java
+++ b/src/main/java/jmeter/plugins/http2/sampler/Http2SettingsHandler.java
@@ -57,7 +57,7 @@ public class Http2SettingsHandler extends SimpleChannelInboundHandler<Http2Setti
     }
 
     @Override
-    protected void messageReceived(ChannelHandlerContext ctx, Http2Settings msg) throws Exception {
+    protected void channelRead0(ChannelHandlerContext ctx, Http2Settings msg) throws Exception {
         promise.setSuccess();
 
         // Only care about the first settings message

--- a/src/main/java/jmeter/plugins/http2/sampler/HttpResponseHandler.java
+++ b/src/main/java/jmeter/plugins/http2/sampler/HttpResponseHandler.java
@@ -84,7 +84,7 @@ public class HttpResponseHandler extends SimpleChannelInboundHandler<FullHttpRes
     }
 
     @Override
-    protected void messageReceived(ChannelHandlerContext ctx, FullHttpResponse msg) throws Exception {
+    protected void channelRead0(ChannelHandlerContext ctx, FullHttpResponse msg) throws Exception {
         Integer streamId = msg.headers().getInt(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text());
         if (streamId == null) {
             System.err.println("HttpResponseHandler unexpected message received: " + msg);
@@ -101,6 +101,7 @@ public class HttpResponseHandler extends SimpleChannelInboundHandler<FullHttpRes
                 int contentLength = content.readableBytes();
                 byte[] arr = new byte[contentLength];
                 content.readBytes(arr);
+                //noinspection Since15
                 System.out.println(new String(arr, 0, contentLength, CharsetUtil.UTF_8));
             }
 

--- a/src/main/java/jmeter/plugins/http2/sampler/HttpResponseHandler.java
+++ b/src/main/java/jmeter/plugins/http2/sampler/HttpResponseHandler.java
@@ -105,10 +105,11 @@ public class HttpResponseHandler extends SimpleChannelInboundHandler<FullHttpRes
                 System.out.println(new String(arr, 0, contentLength, CharsetUtil.UTF_8));
             }
 
-            promise.setSuccess();
-
             // Set result
             streamidResponseMap.put(streamId, msg);
+
+            promise.setSuccess();
+
         }
     }
 }

--- a/src/main/java/jmeter/plugins/http2/sampler/HttpResponseHandler.java
+++ b/src/main/java/jmeter/plugins/http2/sampler/HttpResponseHandler.java
@@ -23,7 +23,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.FullHttpResponse;
-import io.netty.handler.codec.http2.HttpUtil;
+import io.netty.handler.codec.http2.HttpConversionUtil;
 import io.netty.util.CharsetUtil;
 
 import java.util.Iterator;
@@ -85,7 +85,7 @@ public class HttpResponseHandler extends SimpleChannelInboundHandler<FullHttpRes
 
     @Override
     protected void messageReceived(ChannelHandlerContext ctx, FullHttpResponse msg) throws Exception {
-        Integer streamId = msg.headers().getInt(HttpUtil.ExtensionHeaderNames.STREAM_ID.text());
+        Integer streamId = msg.headers().getInt(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text());
         if (streamId == null) {
             System.err.println("HttpResponseHandler unexpected message received: " + msg);
             return;

--- a/src/main/java/jmeter/plugins/http2/sampler/NettyHttp2Client.java
+++ b/src/main/java/jmeter/plugins/http2/sampler/NettyHttp2Client.java
@@ -43,7 +43,6 @@ import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.testelement.property.CollectionProperty;
 import org.apache.jmeter.testelement.property.PropertyIterator;
 
-import javax.net.ssl.SSLException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
@@ -51,6 +50,7 @@ import java.util.Iterator;
 import java.util.Map.Entry;
 import java.util.SortedMap;
 import java.util.concurrent.TimeUnit;
+import javax.net.ssl.SSLException;
 
 import static io.netty.handler.codec.http.HttpMethod.GET;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
@@ -119,7 +119,7 @@ public class NettyHttp2Client {
         }
 
         FullHttpRequest request = new DefaultFullHttpRequest(HTTP_1_1, GET, path);
-        request.headers().addObject(HttpHeaderNames.HOST, hostName);
+        request.headers().add(HttpHeaderNames.HOST, hostName);
 
         // Add request headers set by HeaderManager
         if (headerManager != null) {
@@ -144,7 +144,7 @@ public class NettyHttp2Client {
             // Currently pick up only one response of a stream
             final FullHttpResponse response = responseMap.get(streamId);
             final AsciiString responseCode = response.status().codeAsText();
-            final AsciiString reasonPhrase = response.status().reasonPhrase();
+            final String reasonPhrase = response.status().reasonPhrase();
             sampleResult.setResponseCode(new StringBuilder(responseCode.length()).append(responseCode).toString());
             sampleResult.setResponseMessage(new StringBuilder(reasonPhrase.length()).append(reasonPhrase).toString());
             sampleResult.setResponseHeaders(getResponseHeaders(response));

--- a/src/main/java/jmeter/plugins/http2/sampler/NettyHttp2Client.java
+++ b/src/main/java/jmeter/plugins/http2/sampler/NettyHttp2Client.java
@@ -15,25 +15,7 @@
  */
 package jmeter.plugins.http2.sampler;
 
-import java.net.URI;
-import java.net.URL;
-import java.net.MalformedURLException;
-import java.nio.charset.StandardCharsets;
-import java.util.concurrent.TimeUnit;
-import java.util.SortedMap;
-import java.util.Iterator;
-import java.util.Map.Entry;
-
-import javax.net.ssl.SSLException;
-
-import org.apache.jmeter.protocol.http.control.Header;
-import org.apache.jmeter.protocol.http.control.HeaderManager;
-import org.apache.jmeter.samplers.SampleResult;
-import org.apache.jmeter.testelement.property.CollectionProperty;
-import org.apache.jmeter.testelement.property.PropertyIterator;
-
 import io.netty.bootstrap.Bootstrap;
-import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
@@ -43,10 +25,7 @@ import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpHeaderNames;
-import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http2.Http2SecurityUtil;
-import io.netty.util.AsciiString;
-
 import io.netty.handler.ssl.ApplicationProtocolConfig;
 import io.netty.handler.ssl.ApplicationProtocolConfig.Protocol;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectedListenerFailureBehavior;
@@ -58,9 +37,23 @@ import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import io.netty.util.AsciiString;
+import org.apache.jmeter.protocol.http.control.HeaderManager;
+import org.apache.jmeter.samplers.SampleResult;
+import org.apache.jmeter.testelement.property.CollectionProperty;
+import org.apache.jmeter.testelement.property.PropertyIterator;
 
-import static io.netty.handler.codec.http.HttpMethod.*;
-import static io.netty.handler.codec.http.HttpVersion.*;
+import javax.net.ssl.SSLException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.util.Iterator;
+import java.util.Map.Entry;
+import java.util.SortedMap;
+import java.util.concurrent.TimeUnit;
+
+import static io.netty.handler.codec.http.HttpMethod.GET;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 
 public class NettyHttp2Client {
     private final String method;
@@ -199,7 +192,7 @@ public class NettyHttp2Client {
     private String getResponseHeaders(FullHttpResponse response) {
         StringBuilder headerBuf = new StringBuilder();
 
-        Iterator<Entry<String, String>> iterator = response.headers().iteratorConverted();
+        Iterator<Entry<String, String>> iterator = response.headers().iteratorAsString();
         while(iterator.hasNext()) {
             Entry<String, String> entry = iterator.next();
             headerBuf.append(entry.getKey());

--- a/src/main/java/jmeter/plugins/http2/sampler/gui/HTTP2SamplerGui.java
+++ b/src/main/java/jmeter/plugins/http2/sampler/gui/HTTP2SamplerGui.java
@@ -78,7 +78,7 @@ public class HTTP2SamplerGui extends AbstractSamplerGui {
         /* method.setText(sampler.getMethod()); */
         scheme.setText(sampler.getScheme());
         domain.setText(sampler.getDomain());
-        port.setText(String.valueOf(sampler.getPort()));
+        port.setText(sampler.getPortAsString());
         path.setText(sampler.getPath());
     }
 

--- a/src/main/java/jmeter/plugins/http2/sampler/gui/HTTP2SamplerGui.java
+++ b/src/main/java/jmeter/plugins/http2/sampler/gui/HTTP2SamplerGui.java
@@ -31,6 +31,7 @@ public class HTTP2SamplerGui extends AbstractSamplerGui {
     private static final Logger log = LoggingManager.getLoggerForClass();
 
     private JLabeledChoice method;
+    private JTextField scheme;
     private JTextField domain;
     private JTextField port;
     private JTextField path;
@@ -75,6 +76,7 @@ public class HTTP2SamplerGui extends AbstractSamplerGui {
 
         HTTP2Sampler sampler = (HTTP2Sampler)element;
         /* method.setText(sampler.getMethod()); */
+        scheme.setText(sampler.getScheme());
         domain.setText(sampler.getDomain());
         port.setText(String.valueOf(sampler.getPort()));
         path.setText(sampler.getPath());
@@ -84,6 +86,7 @@ public class HTTP2SamplerGui extends AbstractSamplerGui {
         configureTestElement(element);
         /* element.setProperty(HTTP2Sampler.METHOD, method.getText()); */
         element.setProperty(HTTP2Sampler.METHOD, HTTP2Sampler.DEFAULT_METHOD);
+        element.setProperty(HTTP2Sampler.SCHEME, scheme.getText());
         element.setProperty(HTTP2Sampler.DOMAIN, domain.getText());
         element.setProperty(HTTP2Sampler.PORT, port.getText());
         element.setProperty(HTTP2Sampler.PATH, path.getText());
@@ -92,13 +95,28 @@ public class HTTP2SamplerGui extends AbstractSamplerGui {
     private final JPanel getWebServerPanel() {
         JPanel webServerPanel = new HorizontalPanel();
 
+        final JPanel schemePanel = getSchemePanel();
         final JPanel domainPanel = getDomainPanel();
         final JPanel portPanel = getPortPanel();
 
+        webServerPanel.add(schemePanel, BorderLayout.WEST);
         webServerPanel.add(domainPanel, BorderLayout.CENTER);
         webServerPanel.add(portPanel, BorderLayout.EAST);
 
         return webServerPanel;
+    }
+
+    private final JPanel getSchemePanel() {
+        scheme = new JTextField(10);
+
+        JLabel label = new JLabel("Scheme");
+        label.setLabelFor(scheme);
+
+        JPanel panel = new JPanel(new BorderLayout(5, 0));
+        panel.add(label, BorderLayout.WEST);
+        panel.add(scheme, BorderLayout.CENTER);
+
+        return panel;
     }
 
     private final JPanel getDomainPanel() {

--- a/src/main/java/jmeter/plugins/http2/sampler/gui/HTTP2SamplerGui.java
+++ b/src/main/java/jmeter/plugins/http2/sampler/gui/HTTP2SamplerGui.java
@@ -16,21 +16,15 @@
 package jmeter.plugins.http2.sampler.gui;
 
 import jmeter.plugins.http2.sampler.HTTP2Sampler;
-
-import java.awt.BorderLayout;
-import java.awt.Component;
-
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.JTextField;
-import javax.swing.BoxLayout;
-
 import org.apache.jmeter.gui.util.HorizontalPanel;
 import org.apache.jmeter.samplers.gui.AbstractSamplerGui;
 import org.apache.jmeter.testelement.TestElement;
 import org.apache.jorphan.gui.JLabeledChoice;
 import org.apache.jorphan.logging.LoggingManager;
 import org.apache.log.Logger;
+
+import java.awt.*;
+import javax.swing.*;
 
 public class HTTP2SamplerGui extends AbstractSamplerGui {
 
@@ -63,12 +57,10 @@ public class HTTP2SamplerGui extends AbstractSamplerGui {
         return "HTTP2 Sampler";
     }
 
-    @Override
     public String getLabelResource() {
         return "HTTP2 Sampler";
     }
 
-    @Override
     public TestElement createTestElement() {
         HTTP2Sampler sampler = new HTTP2Sampler();
 
@@ -88,7 +80,6 @@ public class HTTP2SamplerGui extends AbstractSamplerGui {
         path.setText(sampler.getPath());
     }
 
-    @Override
     public void modifyTestElement(TestElement element) {
         configureTestElement(element);
         /* element.setProperty(HTTP2Sampler.METHOD, method.getText()); */


### PR DESCRIPTION
As Netty 5 is not released for quite some time, I have changed the usage to Netty 4.1.x.
Added support for specifying scheme (http/https) which allows to run the sampler against both h2c (with upgrade) and h2 (with ALPN).
Fixed several bugs to make the sampler properly working.
